### PR TITLE
Update composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "google-plus-quickstart/1.0",
+    "name": "googleplus/quickstart",
     "description": "This quick-start app is built in PHP and lets you get started with the Google+ platform in a few minutes.",
     "license": "Apache-2.0",
     "require": {


### PR DESCRIPTION
Went with googleplus as the vendor prefix to match the Github org. My feeling is that when we add to the client library specifically, it will be using the google/ vendor path, but for this project going with the specific area made sense.
